### PR TITLE
Copy & paste loadouts in zeus

### DIFF
--- a/addons/zeus/CfgVehicles.hpp
+++ b/addons/zeus/CfgVehicles.hpp
@@ -42,6 +42,20 @@ class CfgVehicles {
         function = QFUNC(moduleSetEngineer);
         icon = "\z\ace\addons\zeus\ui\Icon_Module_Zeus_Medic_ca.paa";
     };
+    class GVAR(moduleCopyLoadout): EGVAR(common,moduleBase) {
+        curatorCanAttach = 1;
+        category = "Equipment";
+        displayName = "Copy Loadout";
+        function = QFUNC(moduleCopyLoadout);
+        icon = "\achilles\data_f_achilles\icons\icon_position.paa";
+    };
+    class GVAR(modulePasteLoadout): EGVAR(common,moduleBase) {
+        curatorCanAttach = 1;
+        category = "Equipment";
+        displayName = "Paste Loadout";
+        function = QFUNC(modulePasteLoadout);
+        icon = "\achilles\data_f_achilles\icons\icon_position.paa";
+    };
 
     class Ares_Zeus_Module_Base;
     class Ares_Module_Zeus_Visibility: Ares_Zeus_Module_Base {

--- a/addons/zeus/XEH_PREP.hpp
+++ b/addons/zeus/XEH_PREP.hpp
@@ -13,4 +13,6 @@ PREP(moduleSetEngineer);
 PREP(moduleTeleportZeus);
 PREP(moduleToggleAllowUnconcious);
 PREP(moduleToggleZeusVisibility);
+PREP(moduleCopyLoadout);
+PREP(modulePasteLoadout);
 PREP(setAllowUnconcious);

--- a/addons/zeus/XEH_preInit.sqf
+++ b/addons/zeus/XEH_preInit.sqf
@@ -11,4 +11,6 @@ missionNamespace setVariable [QGVAR(curatorNames), ["","","","",""], true];
 GVAR(pingCount) = 0;
 GVAR(pingTime) = 0;
 
+GVAR(loadout) = "";
+
 ADDON = true;

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -10,7 +10,9 @@ class CfgPatches {
             QGVAR(moduleAddAllObjects),
             QGVAR(moduleTeleportZeus),
             QGVAR(moduleToggleAllowUnconcious),
-            QGVAR(moduleSetEngineer)
+            QGVAR(moduleSetEngineer),
+            QGVAR(moduleCopyLoadout),
+            QGVAR(modulePasteLoadout)
         };
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;

--- a/addons/zeus/functions/fnc_moduleCopyLoadout.sqf
+++ b/addons/zeus/functions/fnc_moduleCopyLoadout.sqf
@@ -1,0 +1,34 @@
+/*
+    Author:
+        Tim Beswick
+
+    Description:
+        Copy loadout of unit to global variable
+
+    Parameter(s):
+        0: The module logic <OBJECT>
+        1: Synchronized units <ARRAY>
+        2: Activated <BOOL>
+
+    Return Value:
+        None
+*/
+#include "script_component.hpp"
+
+params ["_logic", "_units", "_activated"];
+
+if !(_activated && local _logic) exitWith {};
+
+(missionNamespace getVariable ["bis_fnc_curatorObjectPlaced_mouseOver", [""]]) params ["_typeName", "_unit"];
+if (_typeName != "OBJECT") then {
+    ["Place on a unit"] call ace_common_fnc_displayTextStructured;
+} else {
+    _unit = effectivecommander _unit;
+    if !(_unit isKindOf "CAManBase") then {
+        ["Place on a unit"] call ace_common_fnc_displayTextStructured;
+    } else {
+        GVAR(loadout) = getUnitLoadout _unit;
+    };
+};
+
+deleteVehicle _logic;

--- a/addons/zeus/functions/fnc_modulePasteLoadout.sqf
+++ b/addons/zeus/functions/fnc_modulePasteLoadout.sqf
@@ -1,0 +1,43 @@
+/*
+    Author:
+        Tim Beswick
+
+    Description:
+        Paste loadout from global variable to unit
+
+    Parameter(s):
+        0: The module logic <OBJECT>
+        1: Synchronized units <ARRAY>
+        2: Activated <BOOL>
+
+    Return Value:
+        None
+*/
+#include "script_component.hpp"
+
+params ["_logic", "_units", "_activated"];
+
+if !(_activated && local _logic) exitWith {};
+
+(missionNamespace getVariable ["bis_fnc_curatorObjectPlaced_mouseOver", [""]]) params ["_typeName", "_unit"];
+if (_typeName != "OBJECT") then {
+    ["Place on a unit"] call ace_common_fnc_displayTextStructured;
+} else {
+    _unit = effectivecommander _unit;
+    if (!(_unit isKindOf "CAManBase")) then {
+        ["Place on a unit"] call ace_common_fnc_displayTextStructured;
+    } else {
+        if (!alive _unit) then {
+            ["Place on a living unit"] call ace_common_fnc_displayTextStructured;
+        } else {
+            if (GVAR(loadout) isEqualTo "") then {
+                ["Copy a loadout first"] call ace_common_fnc_displayTextStructured;
+            } else {
+                _unit setUnitLoadout GVAR(loadout);
+                ["Loadout pasted"] call ace_common_fnc_displayTextStructured;
+            };
+        };
+    };
+};
+
+deleteVehicle _logic;


### PR DESCRIPTION
**When merged this pull request will:**
- Add modules in zeus enabling the copy and paste of unit loadouts.
- Works only client-side, so only the client who placed the copy module can paste that loadout.
