### PR TITLE
Reverted curator login to static number of curators. 

### DIFF
--- a/addons/common/functions/fnc_addObjectsToCurators.sqf
+++ b/addons/common/functions/fnc_addObjectsToCurators.sqf
@@ -22,7 +22,8 @@ if (!isServer) exitWith {
 
 {
     [_x] spawn {
-        (_this select 0) addCuratorEditableObjects [allMissionObjects "all", true];
+        (_this select 0) addCuratorEditableObjects [(allMissionObjects "all"), true];
+        (_this select 0) removeCuratorEditableObjects [allCurators, true];
     };
     false
 } count _curators;

--- a/addons/curator/XEH_postInit.sqf
+++ b/addons/curator/XEH_postInit.sqf
@@ -4,19 +4,23 @@
 if (isServer) then {
     [QGVAR(curatorAssign), {_this call FUNC(curatorAssign)}] call CBA_fnc_addEventHandler;
     [QGVAR(curatorCreate), {_this call FUNC(curatorCreate)}] call CBA_fnc_addEventHandler;
-    [QGVAR(curatorDelete), {_this call FUNC(curatorDelete)}] call CBA_fnc_addEventHandler;
     [QGVAR(curatorUnassign), {_this call FUNC(curatorUnassign)}] call CBA_fnc_addEventHandler;
 };
 if (hasInterface) then {
-    [QGVAR(curatorInit), {_this call FUNC(moduleCuratorLocal)}] call CBA_fnc_addEventHandler;
     [QGVAR(curatorLogout), {_this call FUNC(curatorLogout)}] call CBA_fnc_addEventHandler;
 };
 
 //Start curator access
 if (isServer) then {
-    addMissionEventHandler ["HandleDisconnect", {[QGVAR(curatorDelete), [getAssignedCuratorLogic (_this select 0)]] call CBA_fnc_serverEvent;}];
+    addMissionEventHandler ["HandleDisconnect", {[QGVAR(curatorUnassign), [getAssignedCuratorLogic (_this select 0)]] call CBA_fnc_serverEvent;}];
+    if (isMultiplayer) then {
+        for "_i" from 1 to GVAR(curatorsMax) do {
+            call FUNC(curatorCreate);
+        };
+    };
 };
 if (!isMultiplayer) then {
+    call FUNC(curatorCreate);
     call FUNC(curatorLogin);
 };
 if (hasInterface) then {

--- a/addons/curator/functions/fnc_curatorAssign.sqf
+++ b/addons/curator/functions/fnc_curatorAssign.sqf
@@ -18,6 +18,6 @@
 params ["_player", ["_curator", objNull]];
 
 if (isNull _curator) then {
-    _curator = GVAR(curatorObjects) select ((count GVAR(curatorObjects)) - 1);
+    _curator = (GVAR(curatorObjects) select {isNull (getAssignedCuratorUnit _x)}) select 0;
 };
 _player assignCurator _curator;

--- a/addons/curator/functions/fnc_curatorCreate.sqf
+++ b/addons/curator/functions/fnc_curatorCreate.sqf
@@ -6,19 +6,16 @@
         Creates a new curator
 
     Parameter(s):
-        0: Curator player <OBJECT>
+        None
 
     Return Value:
         None
 */
 #include "script_component.hpp"
 
-params ["_player"];
-
 if (isNull GVAR(curatorGroup)) then {
     GVAR(curatorGroup) = creategroup sideLogic;
 };
 private _curator = GVAR(curatorGroup) createUnit ["ModuleCuratorLocal", [0,0,0], [], 0, "NONE"];
-[QGVAR(curatorInit), [_curator, [], true], _player] call CBA_fnc_targetEvent;
 GVAR(curatorObjects) pushBack _curator;
 publicVariable QGVAR(curatorObjects);

--- a/addons/curator/functions/fnc_curatorLogin.sqf
+++ b/addons/curator/functions/fnc_curatorLogin.sqf
@@ -13,9 +13,6 @@
 */
 #include "script_component.hpp"
 
-if (isMultiplayer || {!isMultiplayer && {GVAR(curatorObjects) isEqualTo []}}) then {
-    [QGVAR(curatorCreate), [player]] call CBA_fnc_serverEvent;
-};
 [QGVAR(curatorAssign), [player]] call CBA_fnc_serverEvent;
 [QEGVAR(common,adminHint), [format ["%1 logged in", name player]]] call CBA_fnc_globalEvent;
 [QEGVAR(common,serverLog), [format ["%1 logged in", name player]]] call CBA_fnc_serverEvent;

--- a/addons/curator/functions/fnc_curatorUnassign.sqf
+++ b/addons/curator/functions/fnc_curatorUnassign.sqf
@@ -16,6 +16,3 @@
 params ["_curator"];
 
 unassignCurator _curator;
-if (isMultiplayer) then {
-    [QGVAR(curatorDelete), [_curator]] call CBA_fnc_serverEvent;
-};

--- a/addons/curator/script_component.hpp
+++ b/addons/curator/script_component.hpp
@@ -11,8 +11,8 @@
 #define CURATOR_ICON "\A3\Ui_F_Curator\Data\Logos\arma3_zeus_icon_ca.paa"
 
 #define MULTIPLAYER_ADMIN isMultiplayer && (ADMIN_OR_HOST)
-#define CONDITION_LOGIN ((ADMIN_OR_HOST) || {!GVAR(curatorsLocked)}) && {isNull (getAssignedCuratorLogic player)} && {(count GVAR(curatorObjects)) < GVAR(curatorsMax)}
+#define CONDITION_LOGIN ((ADMIN_OR_HOST) || {!GVAR(curatorsLocked)}) && {isNull (getAssignedCuratorLogic player)} && {({isNull (getAssignedCuratorUnit _x)} count GVAR(curatorObjects)) > 0}
 #define CONDITION_LOGOUT ((ADMIN_OR_HOST) || {!GVAR(curatorsLocked)}) && {!isNull (getAssignedCuratorLogic player)} && {(getAssignedCuratorLogic player) in GVAR(curatorObjects)}
 #define CONDITION_LOCK MULTIPLAYER_ADMIN && {!GVAR(curatorsLocked)}
 #define CONDITION_UNLOCK MULTIPLAYER_ADMIN && {GVAR(curatorsLocked)}
-#define CONDITION_KICKALL MULTIPLAYER_ADMIN && {!(GVAR(curatorObjects) isEqualTo [])}
+#define CONDITION_KICKALL MULTIPLAYER_ADMIN && {({!(isNull (getAssignedCuratorUnit _x))} count GVAR(curatorObjects)) > 1}

--- a/addons/zeus/CfgFunctions.hpp
+++ b/addons/zeus/CfgFunctions.hpp
@@ -1,13 +1,4 @@
 class CfgFunctions {
-    class Achilles {
-        class Init {
-            class onCuratorStart { file = QPATHTOF(functions\fnc_onCuratorStart.sqf); };
-        };
-        class ui_f_displayCurator {
-            class onDisplayCuratorLoad { file = QPATHTOF(functions\fnc_onDisplayCuratorLoad.sqf); };
-            class onModuleTreeLoad { file = QPATHTOF(functions\fnc_onModuleTreeLoad.sqf); };
-        };
-    };
     class A3_Functions_F_Curator {
         class Curator {
             delete curatorPinged;
@@ -17,6 +8,20 @@ class CfgFunctions {
         class Achilles {
             delete curatorObjectPlaced;
             delete showCuratorAttributes;
+        };
+    };
+    class Achilles {
+        class Init {
+            class onCuratorStart { file = QPATHTOF(functions\fnc_onCuratorStart.sqf); };
+        };
+        class ui_f_displayCurator {
+            class onDisplayCuratorLoad { file = QPATHTOF(functions\fnc_onDisplayCuratorLoad.sqf); };
+            class onModuleTreeLoad { file = QPATHTOF(functions\fnc_onModuleTreeLoad.sqf); };
+        };
+    };
+    class Ares {
+        class functions_f_features {
+            class AddUnitsToCurator { file = QPATHTOF(functions\fnc_addUnitsToCurator.sqf); };
         };
     };
 };

--- a/addons/zeus/functions/fnc_addUnitsToCurator.sqf
+++ b/addons/zeus/functions/fnc_addUnitsToCurator.sqf
@@ -1,0 +1,30 @@
+/*
+	Adds (or removes) a set of objects to all of the curator modules that are active.
+	
+	Parameters:
+		0 - Array - The set of objects to add or remove from curator control.
+		1 - Boolean - True to add the objects to curator control, false to remove them from curator control. Default is True.
+*/
+
+_unitsToModify = [_this, 0, [], [[]]] call BIS_fnc_param;
+_addToCurator = [_this, 1, true, [true]] call BIS_fnc_param;
+
+if (isNil "Ares_addUnitsToCuratorFunction") then {
+	Ares_addUnitsToCuratorFunction = {
+		if (_this select 1) then {
+            {
+                [_x, (_this select 0)] spawn {
+                    (_this select 0) addCuratorEditableObjects [(_this select 1), true];
+                    (_this select 0) removeCuratorEditableObjects [allCurators, true];
+                };
+                false
+            } count allCurators;
+		} else {
+			{_x removeCuratorEditableObjects [(_this select 0), true]; false} count allCurators;
+		};
+	};
+	publicVariable "Ares_addUnitsToCuratorFunction";
+};
+
+[[_unitsToModify, _addToCurator], "Ares_addUnitsToCuratorFunction", false] call BIS_fnc_MP;
+true

--- a/addons/zeus/functions/fnc_addUnitsToCurator.sqf
+++ b/addons/zeus/functions/fnc_addUnitsToCurator.sqf
@@ -1,17 +1,24 @@
 /*
-	Adds (or removes) a set of objects to all of the curator modules that are active.
-	
-	Parameters:
-		0 - Array - The set of objects to add or remove from curator control.
-		1 - Boolean - True to add the objects to curator control, false to remove them from curator control. Default is True.
-*/
+    Author:
+        Kex, Tim Beswick
 
-_unitsToModify = [_this, 0, [], [[]]] call BIS_fnc_param;
-_addToCurator = [_this, 1, true, [true]] call BIS_fnc_param;
+    Description:
+        Adds (or removes) a set of objects to all of the curator modules that are active.
+
+    Parameter(s):
+        0: Objects <ARRAY>
+        1: Add or remove <BOOL>
+
+    Return Value:
+        None
+*/
+#include "script_component.hpp"
+
+params [["_unitsToModify", [], [[]]], ["_addToCurator", true, [true]]];
 
 if (isNil "Ares_addUnitsToCuratorFunction") then {
-	Ares_addUnitsToCuratorFunction = {
-		if (_this select 1) then {
+    Ares_addUnitsToCuratorFunction = {
+        if (_this select 1) then {
             {
                 [_x, (_this select 0)] spawn {
                     (_this select 0) addCuratorEditableObjects [(_this select 1), true];
@@ -19,11 +26,11 @@ if (isNil "Ares_addUnitsToCuratorFunction") then {
                 };
                 false
             } count allCurators;
-		} else {
-			{_x removeCuratorEditableObjects [(_this select 0), true]; false} count allCurators;
-		};
-	};
-	publicVariable "Ares_addUnitsToCuratorFunction";
+        } else {
+            {_x removeCuratorEditableObjects [(_this select 0), true]; false} count allCurators;
+        };
+    };
+    publicVariable "Ares_addUnitsToCuratorFunction";
 };
 
 [[_unitsToModify, _addToCurator], "Ares_addUnitsToCuratorFunction", false] call BIS_fnc_MP;


### PR DESCRIPTION
**When merged this pull request will:**
- Revert to previous curator login design with a set number of curators created at the start of the mission.
- The number created depends on the maximum allowed, set by mission settings.
- When adding objects to zeus, curator objects will be removed.
