### PR TITLE
Moving targets

### DIFF
--- a/addons/gear/CfgVehicles.hpp
+++ b/addons/gear/CfgVehicles.hpp
@@ -726,20 +726,6 @@ class CfgVehicles {
         displayName = "Supply Crate (Arsenal)";
     };
 
-    class TargetP_Inf_F;
-    class UKSF_Target_Nopopup: TargetP_Inf_F {
-        scope = 2;
-        scopeCurator = 2;
-        displayName = "Figure 11 Target - No Popup";
-        editorCategory = QEGVAR(common,UKSF);
-        editorSubcategory = QEGVAR(common,support);
-        editorPreview = QPATHTOEF(common,data\previews\UKSF_Target_Nopopup.jpg);
-        class EventHandlers {
-            hitPart = "";
-            class cba_Extended_EventHandlers: cba_Extended_EventHandlers {};
-        };
-    };
-
     class CUP_USBasicAmmunitionBox;
     class CUP_USLaunchersBox: CUP_USBasicAmmunitionBox {
         class TransportMagazines {

--- a/addons/gear/config.cpp
+++ b/addons/gear/config.cpp
@@ -38,8 +38,7 @@ class CfgPatches {
             "UKSF_S_Medic",
             "UKSF_S_AmmoMedic",
             "UKSF_S_Radios",
-            "UKSF_S_Arsenal",
-            "UKSF_Target_Nopopup"
+            "UKSF_S_Arsenal"
         };
         weapons[] = {
             "UK3CB_BAF_U_CombatUniform_MTP_1Para",

--- a/addons/special/CfgVehicles.hpp
+++ b/addons/special/CfgVehicles.hpp
@@ -118,4 +118,51 @@ class CfgVehicles {
         function = QFUNC(moduleMakeBomb);
         icon = "\z\ace\addons\explosives\UI\Icon_Module_Explosives_ca.paa";
     };
+
+    class TargetP_Inf_F;
+    class UKSF_Target_Nopopup: TargetP_Inf_F {
+        scope = 2;
+        scopeCurator = 2;
+        displayName = "Figure 11 Target - No Popup";
+        editorCategory = QEGVAR(common,UKSF);
+        editorSubcategory = QEGVAR(common,support);
+        editorPreview = QPATHTOEF(common,data\previews\UKSF_Target_Nopopup.jpg);
+        class EventHandlers {
+            hitPart = "";
+            class cba_Extended_EventHandlers: cba_Extended_EventHandlers {};
+        };
+    };
+    class Sign_sphere10cm_EP1;
+    class UKSF_Target_Moving: Sign_sphere10cm_EP1 {
+        scope = 2;
+        scopeCurator = 2;
+        displayName = "Movable Figure 11 Target";
+        editorCategory = QEGVAR(common,UKSF);
+        editorSubcategory = QEGVAR(common,support);
+        editorPreview = QPATHTOEF(common,data\previews\UKSF_Target_Nopopup.jpg);
+        model = "\A3\Structures_F\Training\Target_PopUp_F.p3d";
+        icon = "iconObject_5x4";
+        class DestructionEffects {
+        };
+        class AnimationSources {
+            class Terc {
+                animPeriod = 0.35;
+            };
+        };
+        hiddenSelections[] = { "camo", "target2", "target3" };
+        hiddenSelectionsTextures[] = { "a3\structures_f\training\data\target_inf_co", "#(argb,8,8,3)color(0,0,0,0,ca)", "#(argb,8,8,3)color(0,0,0,0,ca)" };
+        mapSize = 0.72;
+        class SimpleObject {
+            eden = 0;
+            animate[] = {{"terc", 0}};
+            hide[] = {};
+            verticalOffset = 0.858;
+            verticalOffsetWorld = 0;
+            init = "''";
+        };
+        class EventHandlers {
+            class CBA_Extended_EventHandlers: CBA_Extended_EventHandlers {};
+            hitPart = "_this select 0 execVM '\A3\Structures_F\Training\data\scripts\TargetP_Inf_F_hitPart.sqf';";
+        };
+    };
 };

--- a/addons/special/XEH_PREP.hpp
+++ b/addons/special/XEH_PREP.hpp
@@ -2,3 +2,4 @@ PREP(init);
 PREP(suicide);
 PREP(carbomb);
 PREP(moduleMakeBomb);
+PREP(movingTarget);

--- a/addons/special/XEH_postInit.sqf
+++ b/addons/special/XEH_postInit.sqf
@@ -5,4 +5,8 @@ if (isServer) then {
     [{
         call FUNC(cleanupCheck);
     }, [], 5] call cba_fnc_waitAndExecute;
+
+    ["UKSF_Target_Moving", "init", {
+        (_this select 0) setVariable [QGVAR(startPosition), position (_this select 0), true];
+    }, false, [], true] call CBA_fnc_addClassEventHandler;
 };

--- a/addons/special/XEH_preInit.sqf
+++ b/addons/special/XEH_preInit.sqf
@@ -4,4 +4,6 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
+[QGVAR(movingTarget), {_this call FUNC(movingTarget)}] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/addons/special/config.cpp
+++ b/addons/special/config.cpp
@@ -15,7 +15,8 @@ class CfgPatches {
             QGVAR(moduleMakeSuicideBomberDeadman),
             QGVAR(moduleMakeCarBomber),
             QGVAR(moduleMakeCarBomberDeadman),
-            QGVAR(moduleMakeCarBomb)
+            QGVAR(moduleMakeCarBomb),
+            "UKSF_Target_Nopopup"
         };
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
@@ -31,6 +32,7 @@ class CfgPatches {
     };
 };
 
+class CBA_Extended_EventHandlers;
 #include "CfgEventHandlers.hpp"
 #include "Cfg3den.hpp"
 #include "CfgSounds.hpp"

--- a/addons/special/functions/fnc_movingTarget.sqf
+++ b/addons/special/functions/fnc_movingTarget.sqf
@@ -1,0 +1,62 @@
+/*
+    Author:
+        Tim Beswick
+
+    Description:
+        Moving target
+
+    Parameter(s):
+        0: Target <OBJECT>
+        1: Travel direction <SCALAR>
+        2: Travel distance <SCALAR>
+        3: Travel speed in m/s<SCALAR>
+        4: Timout <SCALAR>
+        5: Pause <SCALAR>
+
+    Return Value:
+        Nothing
+*/
+#include "script_component.hpp"
+
+params ["_target", "_direction", "_distance", "_speed", ["_timeout", 10], ["_pause", 2]];
+
+if (!local _target) exitWith {
+    [QGVAR(movingTarget), _this, _target] call CBA_fnc_targetEvent;
+};
+
+if (_target getVariable [QGVAR(moving), false]) exitWith {};
+_target setVariable [QGVAR(moving), true, true];
+
+private _startPosition = _target getVariable [QGVAR(startPosition), position _target];
+private _vectorDir = vectorDir _target;
+_vectorDir set [0, sin _direction];
+_vectorDir set [1, cos _direction];
+_speed = _speed / 60;
+private _steps = _distance / _speed;
+private _startTime = time;
+_pause = (_pause * 15);
+
+[{
+    params ["_args", "_idPFH"];
+    _args params ["_target", "_startPosition", "_vectorDir", "_speed", "_steps", "_currentSteps", "_step", "_startTime", "_timeout", "_pause"];
+
+    if ((time > (_startTime + _timeout)) && {_currentSteps <= 0}) exitWith {
+        _target setVariable [QGVAR(moving), false, true];
+        [_idPFH] call CBA_fnc_removePerFrameHandler;
+    };
+
+    if (_currentSteps < _steps && {_currentSteps > 0}) then {
+        private _newPosition = (_startPosition vectorDiff (_vectorDir vectorMultiply (_currentSteps * _speed)));
+        _newPosition set [2, 0];
+        _target setPos _newPosition;
+    };
+
+    if (_currentSteps >= _steps + _pause) then {
+        _args set [6, -1];
+    } else {
+        if (_currentSteps <= 0 - _pause) then {
+            _args set [6, 1];
+        };
+    };
+    _args set [5, _currentSteps + _step];
+}, 0, [_target, _startPosition, _vectorDir, _speed, _steps, 1, 1, _startTime, _timeout, _pause]] call CBA_fnc_addPerFrameHandler;


### PR DESCRIPTION
**When merged this pull request will:**
- Add moving target object. Behaves like normal target with default popup behaviour.
- Classname `UKSF_Target_Moving`
- Available in `UKSF > Support` in Empty objects section in Eden and Zeus.
- Requires function to be executed for each move cycle.
- `[target, direction, distance, speed, timeout, pause] call uksf_sepcial_fnc_movingTarget`
- Speed should be given in metres per second.
- Timeout defines the duration the target will move. It will complete its cycle before stopping.
- Pause defines how many seconds the target will pause at the end of each movement.
- Init example: `[this, (direction this) + 90, 10, 5, 10, 2] call uksf_sepcial_fnc_movingTarget`

Closes #300 
