### PR TITLE
Update masses of Javelin tubes and missile

### DIFF
--- a/addons/weapons/CfgMagazines.hpp
+++ b/addons/weapons/CfgMagazines.hpp
@@ -31,6 +31,12 @@ class CfgMagazines {
         tracersEvery = 1;
     };
 
+    // Javelin
+    class CA_LauncherMagazine;
+    class UK3CB_BAF_Javelin_Mag : CA_LauncherMagazine {
+        mass = 260;
+    };
+
     // Hellfire K
     class 12Rnd_PG_missiles;
     class 6Rnd_ACE_Hellfire_AGM114K: 12Rnd_PG_missiles {

--- a/addons/weapons/CfgWeapons.hpp
+++ b/addons/weapons/CfgWeapons.hpp
@@ -433,7 +433,10 @@ class CfgWeapons {
             };
         };
     };
-    class Launcher_Base_F;
+    class Launcher;
+    class Launcher_Base_F : Launcher {
+        class WeaponSlotsInfo;
+    };
     class launch_NLAW_F : Launcher_Base_F {
         modes[] = { "Overfly", "Single" };
     };
@@ -467,20 +470,23 @@ class CfgWeapons {
             allowedSlots[] = { 901 };
         };
     };
-    class launch_B_Titan_short_F;
+    class launch_Titan_short_base;
+    class launch_B_Titan_short_F : launch_Titan_short_base {
+        class WeaponSlotsInfo;
+    };
     class UK3CB_BAF_Javelin_Launcher : launch_B_Titan_short_F {
         modes[] = { "Single", "TopDown" };
-        class WeaponSlotsInfo {
+        class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 231;
         };
     };
     class UK3CB_BAF_Javelin_Slung_Tube : Launcher_Base_F {
-        class WeaponSlotsInfo {
+        class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 350;
         };
     }
     class UK3CB_BAF_Javelin_Slung_Tube_Used : UK3CB_BAF_Javelin_Slung_Tube {
-        class WeaponSlotsInfo {
+        class WeaponSlotsInfo : WeaponSlotsInfo {
             mass = 90;
         };
     };

--- a/addons/weapons/CfgWeapons.hpp
+++ b/addons/weapons/CfgWeapons.hpp
@@ -463,13 +463,26 @@ class CfgWeapons {
         delete OpticsModes;
         delete WeaponSlotsInfo;
         class ItemInfo : CBA_MiscItem_ItemInfo {
-            mass = 64;
+            mass = 141;
             allowedSlots[] = { 901 };
         };
     };
     class launch_B_Titan_short_F;
     class UK3CB_BAF_Javelin_Launcher : launch_B_Titan_short_F {
         modes[] = { "Single", "TopDown" };
+        class WeaponSlotsInfo {
+            mass = 231;
+        };
+    };
+    class UK3CB_BAF_Javelin_Slung_Tube : Launcher_Base_F {
+        class WeaponSlotsInfo {
+            mass = 350;
+        };
+    }
+    class UK3CB_BAF_Javelin_Slung_Tube_Used : UK3CB_BAF_Javelin_Slung_Tube {
+        class WeaponSlotsInfo {
+            mass = 90;
+        };
     };
 
     class Default;


### PR DESCRIPTION
**When merged this pull request will:**

* Update the masses of Javelin related items as per #619.

  |Item|Mass|
  |-|-|
  |UK3CB_BAF_Javelin_Mag|260|
  |UK3CB_BAF_Javelin_Slung_Tube|350|
  |UK3CB_BAF_Javelin_Slung_Tube_Used|90|
  |UK3CB_BAF_Javelin_CLU|141|
  |UK3CB_BAF_Javelin_Launcher|231|

* Resolve #619 