### PR TITLE
ci: authenticate hemtt setup to avoid 403 rate limit

### DIFF
--- a/.github/workflows/arma.yml
+++ b/.github/workflows/arma.yml
@@ -14,6 +14,8 @@ jobs:
       uses: actions/checkout@v6
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run HEMTT check
       run: hemtt check
     - name: Check for BOM
@@ -28,5 +30,7 @@ jobs:
       uses: actions/checkout@v6
     - name: Setup HEMTT
       uses: arma-actions/hemtt@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Run HEMTT build
       run: hemtt build


### PR DESCRIPTION
## Summary
- Setup HEMTT action fetches latest release from GitHub API; anonymous calls from shared runners hit rate limits (403).
- Pass GITHUB_TOKEN to both lint and build jobs so the action authenticates.

## Test plan
- [ ] Re-run a PR build and confirm Setup HEMTT step succeeds.